### PR TITLE
Fix undefined variable usage in notebook

### DIFF
--- a/ML.ipynb
+++ b/ML.ipynb
@@ -2134,15 +2134,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "accuracy_score(y_test, y_pred3)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 91,
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
## Summary
- remove stray cell that referenced `y_pred3` before it was defined

## Testing
- `python3 -m json.tool ML.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_685c4cd9294c832e92054d7d0ddb2e5a